### PR TITLE
Add encoding setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ For example, the config file for CoffeeScript would be `coffeescript.cson`.
 
 The API for setting editor settings currently only supports:
 
-- Font family
-- Font size
-- Tab length
-- Soft/hard tabs
-- Soft wrap
-- Invisible characters
-- Showing/hiding invisibles
-- Showing/hiding indent guide
+- Font family (fontFamily)
+- Font size (fontSize)
+- Tab length (tabLength)
+- Soft/hard tabs (softTabs)
+- Soft wrap (softWrap)
+- Invisible characters (invisibles)
+- Showing/hiding invisibles (showInvisibles)
+- Showing/hiding indent guide (showIndentGuide)
+- Encoding (encoding)
 
 ### Example configuration
 

--- a/lib/editor-settings.coffee
+++ b/lib/editor-settings.coffee
@@ -114,6 +114,7 @@ module.exports =
     editor.setTabLength config.tabLength if config.tabLength?
     editor.setSoftTabs  config.softTabs  if config.softTabs?
     editor.setSoftWrap  config.softWrap  if config.softWrap?
+    editor.setEncoding  config.encoding  if config.encoding?
 
     # Invisible characters
     if not config.showInvisibles


### PR DESCRIPTION
With Atom, user can specify globally the file encoding. With this new setting, user can specify the encoding by grammar, file extension, ...
