### PR TITLE
Allow Theme Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The API for setting editor settings currently only supports:
 - Soft/hard tabs (softTabs)
 - Soft wrap (softWrap)
 - Encoding (encoding)
+- Atom and Syntax theme (themes)
 
 ### Example configuration
 
@@ -43,6 +44,7 @@ the file extension is `.cson` it sets it to `4`.
 All options not nested under a specific grammar are used for all grammar and extensions.
 
     tabLength: 2
+    themes: ['atom-light-ui', 'atom-light-syntax']
     grammarConfig:
       'PHP':
         tabLength: 4

--- a/lib/editor-settings.coffee
+++ b/lib/editor-settings.coffee
@@ -66,6 +66,7 @@ module.exports =
       editor.setTabLength   config.tabLength if config.tabLength?
       editor.setSoftTabs    config.softTabs  if config.softTabs?
       editor.setSoftWrapped config.softWrap  if config.softWrap?
+      atom.config.settings.core.themes = [config.themes[0], config.themes[1]] if config.themes?
 
       if editor.buffer?
         buffer = editor.buffer


### PR DESCRIPTION
As a user, I want to be able to have multiple Atom windows open with different theme settings so I can more easily distinguish between my open projects.

The solution is a slightly less than beautiful way of changing the syntax theme, but it's functional.

I couldn't find a way to modify Atom's theme settings using the API, if anyone knows of a better way to do it I'm all ears :smile_cat: 